### PR TITLE
Investigate Topics and Services not Starting on Agent connection

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,6 +18,7 @@ board_microros_distro = iron
 monitor_speed = 115200
 build_flags = 
     -I /home/legohead259/PlatformIO/Projects/BLDC-Motor-Driver/.pio/libdeps/micro_ros_bldc/micro_ros_platformio/libmicroros/include
+    -I /home/legohead259/PlatformIO/Projects/BLDC-Motor-Driver/variants/
 
 [env:micro_ros_esc]
 build_src_filter =  +<*> -<examples/>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,7 +10,7 @@ void setup() {
     sensor.begin(TMAG5273_I2C_ADDRESS_INITIAL);
 
     ledStateMachine.begin();
-    // focBLDCSetup();
+    focBLDCSetup();
     microROSNodeSetup();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,8 +10,8 @@ void setup() {
     sensor.begin(TMAG5273_I2C_ADDRESS_INITIAL);
 
     ledStateMachine.begin();
-    focBLDCSetup();
     microROSNodeSetup();
+    focBLDCSetup();
 }
 
 void loop() {

--- a/src/micro_ros_bldc.cpp
+++ b/src/micro_ros_bldc.cpp
@@ -92,14 +92,14 @@ bool createEntities() {
     RCCHECK(rclc_node_init_default(&node, "bldc_node", "", &support));
 
     // Create application components
-    createPublishers();
+    // createPublishers();
     createServices();
     createTimers();
 
     // Create executor
     RCCHECK(rclc_executor_init(&executor, &support.context, 10, &allocator));
     addServices();
-    addTimers();
+    // addTimers();
 
     return true;
 }


### PR DESCRIPTION
Sometimes, the services and publishers on the Micro-ROS device do not work when connected to the ROS2 agent. This typically happens when the FOC algorithm is active.

Closes #11 , when completed